### PR TITLE
ページ高速化チューニング

### DIFF
--- a/css/mics.css
+++ b/css/mics.css
@@ -219,12 +219,12 @@ header{
     margin:0 auto;
 }
 .graphA2inner {
-    width:90%;
+    width:100%;
     margin:0 auto;
     display:flex;
 }
 .A21{
-    width:45%;
+    width:50%;
     margin:0 auto;
     text-align: center;
 }
@@ -235,25 +235,27 @@ header{
 .A21 hr{
     border:solid 1px #e2e2e2;
     position:relative;
-	left:-14%;
+	left:3%;
     border-radius: 5px;
     width:125%;
     margin:0 auto;
 }
 .A22{
-    width:45%;
+    width:50%;
     margin:0 auto;
     text-align: center;
 }
 .A22 h2{
     color:#5c5c5c;
+    position:relative;
+    left:-10%;
     font-weight: 300;
-    
+    width:120%;
 }
 .A22 hr{
     border:solid 1px #e2e2e2;
     position:relative;
-    left:-12%;
+    left:-29%;
     border-radius: 5px;
     width:125%;
     margin:0 auto;
@@ -474,14 +476,13 @@ footer{
     align-items:center;
 }
 .footertitle{
-    
     margin-left:2%;
     margin-right: auto;
     color: white;
 }
 
 /* レスポンシブ対応 */
-@media screen and (max-width: 1440px) {
+@media screen and (max-width: 1280px) {
 
     .graphA{
         width:100%;

--- a/index.html
+++ b/index.html
@@ -4,26 +4,26 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <title>MICS</title>
-    <link rel="stylesheet" href="css/mics.css">
-    <link rel="icon" href="img/micslogo.svg">
-    <!-- External Source -->
-    <script defer src="https://unpkg.com/axios/dist/axios.min.js"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0/dist/chart.min.js"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/chartjs-plugin-stacked100@1.0.0"></script>
-
     <!-- Our Source -->
     <script defer src="js/search.js"></script>
     <script defer src="js/datain.js"></script>
     <script defer src="js/grahp.js"></script>
     <script defer src="js/mics.js"></script>
+    <!-- External Source -->
+    <script defer src="https://unpkg.com/axios/dist/axios.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0/dist/chart.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/chartjs-plugin-stacked100@1.0.0"></script>
+
+    <title>MICS</title>
+    <link rel="stylesheet" href="css/mics.css">
+    <link rel="icon" href="img/micslogo.svg">
   </head>
   <body>
     <header>
       <h1 class="logo"><a href="#"><img src="img/micslogo.svg" alt="サイトタイトル"></a></h1>
       <h1 class="title">MICS｜Analytics</h1>
     </header>
-    <div class="container" id="serch_container">
+    <div class="container" id="search_container">
       <div class="searcharea">
         <h1>グラフ描画</h1>
         <hr noshade> 

--- a/js/datain.js
+++ b/js/datain.js
@@ -11,25 +11,25 @@ class DataIN{
   
         //選択期間　0分～3時間
         if(bet_time<10800 && bet_time>=0){
-            this.data_process(10800,600,18,d1,d2,InterestData);
+            this.#data_process(10800,600,18,d1,d2,InterestData);
             console.log("[Info] 0~3hour");
         }
         //選択期間　3時間～1日
         else if (bet_time<86400 && bet_time>=10800){
-            this.data_process(86400,3600,24,d1,d2,InterestData);
+            this.#data_process(86400,3600,24,d1,d2,InterestData);
             console.log("[Info] 3h~1d");
         
         }
         //選択期間　1日～31日
         else if(bet_time<=2678400 && bet_time>=86400){
-            this.data_process(2678400,86400,31,d1,d2,InterestData);
+            this.#data_process(2678400,86400,31,d1,d2,InterestData);
             console.log("[Info] 1d~31d");
         };
 
     };
 
     //データ分割関数
-    data_process(max_time,div_time,plot_num,user_intime,user_outtime,InterestData){
+    #data_process(max_time,div_time,plot_num,user_intime,user_outtime,InterestData){
 
         let backdata_arr = JSON.parse(InterestData);
 

--- a/js/datain.js
+++ b/js/datain.js
@@ -38,69 +38,69 @@ class DataIN{
         let not_intline = 20;
 
         //graphプロットデータ変数
-        let A1_data  = [];
-        let A21_data = [];
-        let A22_data = [];
+        this.A1_data  = [];
+        this.A21_data = [];
+        this.A22_data = [];
 
-        let B1_10_data = [];
-        let B1_20_data = [];
-        let B1_30_data = [];
-        let B1_40_data = [];
-        let B1_50_data = [];
-        let B1_60_data = [];
+        this.B1_10_data = [];
+        this.B1_20_data = [];
+        this.B1_30_data = [];
+        this.B1_40_data = [];
+        this.B1_50_data = [];
+        this.B1_60_data = [];
 
-        let B2_10_data = [];
-        let B2_20_data = [];
-        let B2_30_data = [];
-        let B2_40_data = [];
-        let B2_50_data = [];
-        let B2_60_data = [];
+        this.B2_10_data = [];
+        this.B2_20_data = [];
+        this.B2_30_data = [];
+        this.B2_40_data = [];
+        this.B2_50_data = [];
+        this.B2_60_data = [];
 
-        let C1_maxint_data   = [];
-        let C1_nomalint_data = [];
-        let C1_notint_data   = [];
+        this.C1_maxint_data   = [];
+        this.C1_nomalint_data = [];
+        this.C1_notint_data   = [];
 
-        let D11_10_data = [];
-        let D11_20_data = [];
-        let D11_30_data = [];
-        let D11_40_data = [];
-        let D11_50_data = [];
-        let D11_60_data = [];
+        this.D11_10_data = [];
+        this.D11_20_data = [];
+        this.D11_30_data = [];
+        this.D11_40_data = [];
+        this.D11_50_data = [];
+        this.D11_60_data = [];
 
-        let D12_10_data = [];
-        let D12_20_data = [];
-        let D12_30_data = [];
-        let D12_40_data = [];
-        let D12_50_data = [];
-        let D12_60_data = [];
+        this.D12_10_data = [];
+        this.D12_20_data = [];
+        this.D12_30_data = [];
+        this.D12_40_data = [];
+        this.D12_50_data = [];
+        this.D12_60_data = [];
 
-        let D13_10_data = [];
-        let D13_20_data = [];
-        let D13_30_data = [];
-        let D13_40_data = [];
-        let D13_50_data = [];
-        let D13_60_data = [];
+        this.D13_10_data = [];
+        this.D13_20_data = [];
+        this.D13_30_data = [];
+        this.D13_40_data = [];
+        this.D13_50_data = [];
+        this.D13_60_data = [];
 
-        let D21_10_data = [];
-        let D21_20_data = [];
-        let D21_30_data = [];
-        let D21_40_data = [];
-        let D21_50_data = [];
-        let D21_60_data = [];
+        this.D21_10_data = [];
+        this.D21_20_data = [];
+        this.D21_30_data = [];
+        this.D21_40_data = [];
+        this.D21_50_data = [];
+        this.D21_60_data = [];
 
-        let D22_10_data = [];
-        let D22_20_data = [];
-        let D22_30_data = [];
-        let D22_40_data = [];
-        let D22_50_data = [];
-        let D22_60_data = [];
+        this.D22_10_data = [];
+        this.D22_20_data = [];
+        this.D22_30_data = [];
+        this.D22_40_data = [];
+        this.D22_50_data = [];
+        this.D22_60_data = [];
 
-        let D23_10_data = [];
-        let D23_20_data = [];
-        let D23_30_data = [];
-        let D23_40_data = [];
-        let D23_50_data = [];
-        let D23_60_data = [];
+        this.D23_10_data = [];
+        this.D23_20_data = [];
+        this.D23_30_data = [];
+        this.D23_40_data = [];
+        this.D23_50_data = [];
+        this.D23_60_data = [];
 
 
         let label_unix_in = []; 
@@ -112,14 +112,14 @@ class DataIN{
         let all_int_arr   = [];
         let not_int_arr   = [];
 
-        let mail_max_int_arr   = [];
-        let femail_max_int_arr = [];
+        let male_max_int_arr   = [];
+        let female_max_int_arr = [];
         
-        let femail_all_int_arr = [];
-        let mail_all_int_arr   = [];
+        let male_all_int_arr   = [];
+        let female_all_int_arr = [];
         
         //ラベル変数
-        let label_time_arr = [];
+        this.label_time_arr = [];
 
 
         //時間変化ラベル作成    
@@ -130,7 +130,7 @@ class DataIN{
         for(let i=0 ;i<plot_num ;i=i+1){
             let label_time_in= new Date(label_unix_in[i]*1000);
             let label_time_in_2=label_time_in.getMonth()+1+"/"+label_time_in.getDate()+"/ "+label_time_in.getHours()+":"+label_time_in.getMinutes();
-            label_time_arr.push(label_time_in_2);
+            this.label_time_arr.push(label_time_in_2);
         };
 
         //関心度分割
@@ -148,13 +148,13 @@ class DataIN{
 
         //時間分割無しのgraphプロット変数in
         //A1
-        A1_data = [all_max_int_arr  .length, all_nomal_int_arr.length , all_not_int_arr  .length];
+        this.A1_data = [all_max_int_arr  .length, all_nomal_int_arr.length , all_not_int_arr  .length];
 
         //A21
-        A21_data = [all_mail_max_int_arr_in.length ,all_femail_max_int_arr_in.length];
+        this.A21_data = [all_mail_max_int_arr_in.length ,all_femail_max_int_arr_in.length];
 
         //A22
-        A22_data = [all_mail_all_int_arr_in.length ,all_femail_all_int_arr_in.length] ;    
+        this.A22_data = [all_mail_all_int_arr_in.length ,all_femail_all_int_arr_in.length] ;    
 
         //B1
         let B1_mail_10_data_in   = all_mail_max_int_arr_in.filter(x => x.age < 20);    
@@ -170,12 +170,12 @@ class DataIN{
         let B1_femail_50_data_in = all_femail_max_int_arr_in.filter(x => x.age < 60 && x.age>=50);       
         let B1_femail_60_data_in = all_femail_max_int_arr_in.filter(x => x.age <= 120 && x.age>=60);
 
-        B1_10_data = [B1_mail_10_data_in.length,B1_femail_10_data_in.length];
-        B1_20_data = [B1_mail_20_data_in.length,B1_femail_20_data_in.length];
-        B1_30_data = [B1_mail_30_data_in.length,B1_femail_30_data_in.length];
-        B1_40_data = [B1_mail_40_data_in.length,B1_femail_40_data_in.length];
-        B1_50_data = [B1_mail_50_data_in.length,B1_femail_50_data_in.length];
-        B1_60_data = [B1_mail_60_data_in.length,B1_femail_60_data_in.length];
+        this.B1_10_data = [B1_mail_10_data_in.length,B1_femail_10_data_in.length];
+        this.B1_20_data = [B1_mail_20_data_in.length,B1_femail_20_data_in.length];
+        this.B1_30_data = [B1_mail_30_data_in.length,B1_femail_30_data_in.length];
+        this.B1_40_data = [B1_mail_40_data_in.length,B1_femail_40_data_in.length];
+        this.B1_50_data = [B1_mail_50_data_in.length,B1_femail_50_data_in.length];
+        this.B1_60_data = [B1_mail_60_data_in.length,B1_femail_60_data_in.length];
 
         //B2
         let B2_mail_10_data_in   = all_mail_all_int_arr_in.filter(x => x.age < 20);           
@@ -191,188 +191,145 @@ class DataIN{
         let B2_femail_50_data_in = all_femail_all_int_arr_in.filter(x => x.age < 60 && x.age>=50);             
         let B2_femail_60_data_in = all_femail_all_int_arr_in.filter(x => x.age <= 120 && x.age>=60);   
 
-        B2_10_data = [B2_mail_10_data_in.length,B2_femail_10_data_in.length];
-        B2_20_data = [B2_mail_20_data_in.length,B2_femail_20_data_in.length];
-        B2_30_data = [B2_mail_30_data_in.length,B2_femail_30_data_in.length];
-        B2_40_data = [B2_mail_40_data_in.length,B2_femail_40_data_in.length];
-        B2_50_data = [B2_mail_50_data_in.length,B2_femail_50_data_in.length];
-        B2_60_data = [B2_mail_60_data_in.length,B2_femail_60_data_in.length];
+        this.B2_10_data = [B2_mail_10_data_in.length,B2_femail_10_data_in.length];
+        this.B2_20_data = [B2_mail_20_data_in.length,B2_femail_20_data_in.length];
+        this.B2_30_data = [B2_mail_30_data_in.length,B2_femail_30_data_in.length];
+        this.B2_40_data = [B2_mail_40_data_in.length,B2_femail_40_data_in.length];
+        this.B2_50_data = [B2_mail_50_data_in.length,B2_femail_50_data_in.length];
+        this.B2_60_data = [B2_mail_60_data_in.length,B2_femail_60_data_in.length];
 
 
         //時間分割
         for(let i=0 ;i<max_time ;i=i+div_time){
-            let backdata_arr_time_in= backdata_arr.filter(x => x.end_time_unix <= user_intime+(i+div_time) && x.end_time_unix > user_intime+i );
+            let backdata_arr_time_in = backdata_arr.filter(x => x.end_time_unix <= user_intime+(i+div_time) && x.end_time_unix > user_intime+i );
             backdata_arr_time.push(backdata_arr_time_in);
         };
 
 
         for(let i=0 ;i<plot_num ;i=i+1){
             //関心度分割
-            let max_int_arr_in= backdata_arr_time[i].filter(x => x.interested <=100 && x.interested>=max_intline);
+            let max_int_arr_in = backdata_arr_time[i].filter(x => x.interested <=100 && x.interested>=max_intline);
             max_int_arr.push(max_int_arr_in);
 
-            let nomal_int_arr_in= backdata_arr_time[i].filter(x => x.interested <max_intline && x.interested>not_intline );
+            let nomal_int_arr_in = backdata_arr_time[i].filter(x => x.interested <max_intline && x.interested>not_intline );
             nomal_int_arr.push(nomal_int_arr_in);
 
-            let all_int_arr_in= backdata_arr_time[i].filter(x => x.interested <=100 && x.interested>not_intline );
+            let all_int_arr_in = backdata_arr_time[i].filter(x => x.interested <=100 && x.interested>not_intline );
             all_int_arr.push(all_int_arr_in);
 
-            let not_int_arr_in= backdata_arr_time[i].filter(x => x.interested <=not_intline && x.interested>=0  );
+            let not_int_arr_in = backdata_arr_time[i].filter(x => x.interested <=not_intline && x.interested>=0  );
             not_int_arr.push(not_int_arr_in);
 
             //性別分割
-            let mail_max_int_arr_in= max_int_arr[i].filter(x => x.gender === 0);
-            mail_max_int_arr.push(mail_max_int_arr_in);
+            let mail_max_int_arr_in = max_int_arr[i].filter(x => x.gender === 0);
+            male_max_int_arr.push(mail_max_int_arr_in);
             
-            let femail_max_int_arr_in= max_int_arr[i].filter(x => x.gender === 1);
-            femail_max_int_arr.push(femail_max_int_arr_in);
+            let femail_max_int_arr_in = max_int_arr[i].filter(x => x.gender === 1);
+            female_max_int_arr.push(femail_max_int_arr_in);
 
-            let mail_all_int_arr_in= all_int_arr[i].filter(x => x.gender === 0);
-            mail_all_int_arr.push(mail_all_int_arr_in);
+            let mail_all_int_arr_in = all_int_arr[i].filter(x => x.gender === 0);
+            male_all_int_arr.push(mail_all_int_arr_in);
             
-            let femail_all_int_arr_in= all_int_arr[i].filter(x => x.gender === 1);
-            femail_all_int_arr.push(femail_all_int_arr_in);
+            let femail_all_int_arr_in = all_int_arr[i].filter(x => x.gender === 1);
+            female_all_int_arr.push(femail_all_int_arr_in);
 
 
             //プロットデータ作成
-            C1_maxint_data.push(max_int_arr[i].length);
-            C1_nomalint_data.push(nomal_int_arr[i].length);
-            C1_notint_data.push(not_int_arr[i].length);
 
+            //C1
+            this.C1_maxint_data.push(max_int_arr[i].length);
+            this.C1_nomalint_data.push(nomal_int_arr[i].length);
+            this.C1_notint_data.push(not_int_arr[i].length);
 
-            let D11_10_data_in = max_int_arr[i].filter(x => x.age < 20);                     D11_10_data.push(D11_10_data_in.length); 
+            //D11
+            let D11_10_data_in = max_int_arr[i].filter(x => x.age < 20);
+            let D11_20_data_in = max_int_arr[i].filter(x => x.age < 30 && x.age>=20);
+            let D11_30_data_in = max_int_arr[i].filter(x => x.age < 40 && x.age>=30);
+            let D11_40_data_in = max_int_arr[i].filter(x => x.age < 50 && x.age>=40);
+            let D11_50_data_in = max_int_arr[i].filter(x => x.age < 60 && x.age>=50);
+            let D11_60_data_in = max_int_arr[i].filter(x => x.age <= 120 && x.age>=60);
 
-            let D11_20_data_in = max_int_arr[i].filter(x => x.age < 30 && x.age>=20);        D11_20_data.push(D11_20_data_in.length); 
+            this.D11_10_data.push(D11_10_data_in.length); 
+            this.D11_20_data.push(D11_20_data_in.length); 
+            this.D11_30_data.push(D11_30_data_in.length);
+            this.D11_40_data.push(D11_40_data_in.length);
+            this.D11_50_data.push(D11_50_data_in.length);
+            this.D11_60_data.push(D11_60_data_in.length);
 
-            let D11_30_data_in = max_int_arr[i].filter(x => x.age < 40 && x.age>=30);        D11_30_data.push(D11_30_data_in.length);
+            //D12
+            let D12_10_data_in = male_max_int_arr[i].filter(x => x.age < 20);
+            let D12_20_data_in = male_max_int_arr[i].filter(x => x.age < 30 && x.age>=20);
+            let D12_30_data_in = male_max_int_arr[i].filter(x => x.age < 40 && x.age>=30);
+            let D12_40_data_in = male_max_int_arr[i].filter(x => x.age < 50 && x.age>=40);
+            let D12_50_data_in = male_max_int_arr[i].filter(x => x.age < 60 && x.age>=50);
+            let D12_60_data_in = male_max_int_arr[i].filter(x => x.age <= 120 && x.age>=60); 
 
-            let D11_40_data_in = max_int_arr[i].filter(x => x.age < 50 && x.age>=40);        D11_40_data.push(D11_40_data_in.length);
+            this.D12_10_data.push(D12_10_data_in.length);
+            this.D12_20_data.push(D12_20_data_in.length);
+            this.D12_30_data.push(D12_30_data_in.length);
+            this.D12_40_data.push(D12_40_data_in.length);
+            this.D12_50_data.push(D12_50_data_in.length);
+            this.D12_60_data.push(D12_60_data_in.length);
 
-            let D11_50_data_in = max_int_arr[i].filter(x => x.age < 60 && x.age>=50);        D11_50_data.push(D11_50_data_in.length);
+            //D13
+            let D13_10_data_in = female_max_int_arr[i].filter(x => x.age < 20);
+            let D13_20_data_in = female_max_int_arr[i].filter(x => x.age < 30 && x.age>=20);
+            let D13_30_data_in = female_max_int_arr[i].filter(x => x.age < 40 && x.age>=30);
+            let D13_40_data_in = female_max_int_arr[i].filter(x => x.age < 50 && x.age>=40);
+            let D13_50_data_in = female_max_int_arr[i].filter(x => x.age < 60 && x.age>=50);
+            let D13_60_data_in = female_max_int_arr[i].filter(x => x.age <= 120 && x.age>=60);
 
-            let D11_60_data_in = max_int_arr[i].filter(x => x.age <= 120 && x.age>=60);      D11_60_data.push(D11_60_data_in.length);
+            this.D13_10_data.push(D13_10_data_in.length);
+            this.D13_20_data.push(D13_20_data_in.length);
+            this.D13_30_data.push(D13_30_data_in.length);
+            this.D13_40_data.push(D13_40_data_in.length);
+            this.D13_50_data.push(D13_50_data_in.length);
+            this.D13_60_data.push(D13_60_data_in.length);
 
+            //D21
+            let D21_10_data_in = all_int_arr[i].filter(x => x.age < 20);
+            let D21_20_data_in = all_int_arr[i].filter(x => x.age < 30 && x.age>=20);
+            let D21_30_data_in = all_int_arr[i].filter(x => x.age < 40 && x.age>=30);
+            let D21_40_data_in = all_int_arr[i].filter(x => x.age < 50 && x.age>=40);
+            let D21_50_data_in = all_int_arr[i].filter(x => x.age < 60 && x.age>=50);
+            let D21_60_data_in = all_int_arr[i].filter(x => x.age <= 120 && x.age>=60);
 
-            let D12_10_data_in = mail_max_int_arr[i].filter(x => x.age < 20);                D12_10_data.push(D12_10_data_in.length);
+            this.D21_10_data.push(D21_10_data_in.length);
+            this.D21_20_data.push(D21_20_data_in.length);
+            this.D21_30_data.push(D21_30_data_in.length);
+            this.D21_40_data.push(D21_40_data_in.length);
+            this.D21_50_data.push(D21_50_data_in.length);
+            this.D21_60_data.push(D21_60_data_in.length);
 
-            let D12_20_data_in = mail_max_int_arr[i].filter(x => x.age < 30 && x.age>=20);   D12_20_data.push(D12_20_data_in.length);
+            //D22
+            let D22_10_data_in = male_all_int_arr[i].filter(x => x.age < 20);
+            let D22_20_data_in = male_all_int_arr[i].filter(x => x.age < 30 && x.age>=20);
+            let D22_30_data_in = male_all_int_arr[i].filter(x => x.age < 40 && x.age>=30);
+            let D22_40_data_in = male_all_int_arr[i].filter(x => x.age < 50 && x.age>=40);
+            let D22_50_data_in = male_all_int_arr[i].filter(x => x.age < 60 && x.age>=50);
+            let D22_60_data_in = male_all_int_arr[i].filter(x => x.age <= 120 && x.age>=60);
 
-            let D12_30_data_in = mail_max_int_arr[i].filter(x => x.age < 40 && x.age>=30);   D12_30_data.push(D12_30_data_in.length);
+            this.D22_10_data.push(D22_10_data_in.length);
+            this.D22_20_data.push(D22_20_data_in.length);
+            this.D22_30_data.push(D22_30_data_in.length);
+            this.D22_40_data.push(D22_40_data_in.length);
+            this.D22_50_data.push(D22_50_data_in.length);
+            this.D22_60_data.push(D22_60_data_in.length);
 
-            let D12_40_data_in = mail_max_int_arr[i].filter(x => x.age < 50 && x.age>=40);   D12_40_data.push(D12_40_data_in.length);
+            //D23
+            let D23_10_data_in = female_all_int_arr[i].filter(x => x.age < 20);
+            let D23_20_data_in = female_all_int_arr[i].filter(x => x.age < 30 && x.age>=20);
+            let D23_30_data_in = female_all_int_arr[i].filter(x => x.age < 40 && x.age>=30);
+            let D23_40_data_in = female_all_int_arr[i].filter(x => x.age < 50 && x.age>=40);
+            let D23_50_data_in = female_all_int_arr[i].filter(x => x.age < 60 && x.age>=50);
+            let D23_60_data_in = female_all_int_arr[i].filter(x => x.age <= 120 && x.age>=60); 
 
-            let D12_50_data_in = mail_max_int_arr[i].filter(x => x.age < 60 && x.age>=50);   D12_50_data.push(D12_50_data_in.length);
-
-            let D12_60_data_in = mail_max_int_arr[i].filter(x => x.age <= 120 && x.age>=60); D12_60_data.push(D12_60_data_in.length);
-
-
-            let D13_10_data_in = femail_max_int_arr[i].filter(x => x.age < 20);                D13_10_data.push(D13_10_data_in.length);
-
-            let D13_20_data_in = femail_max_int_arr[i].filter(x => x.age < 30 && x.age>=20);   D13_20_data.push(D13_20_data_in.length);
-
-            let D13_30_data_in = femail_max_int_arr[i].filter(x => x.age < 40 && x.age>=30);   D13_30_data.push(D13_30_data_in.length);
-
-            let D13_40_data_in = femail_max_int_arr[i].filter(x => x.age < 50 && x.age>=40);   D13_40_data.push(D13_40_data_in.length);
-
-            let D13_50_data_in = femail_max_int_arr[i].filter(x => x.age < 60 && x.age>=50);   D13_50_data.push(D13_50_data_in.length);
-
-            let D13_60_data_in = femail_max_int_arr[i].filter(x => x.age <= 120 && x.age>=60); D13_60_data.push(D13_60_data_in.length);
-
-
-            let D21_10_data_in = all_int_arr[i].filter(x => x.age < 20);                D21_10_data.push(D21_10_data_in.length);
-
-            let D21_20_data_in = all_int_arr[i].filter(x => x.age < 30 && x.age>=20);   D21_20_data.push(D21_20_data_in.length);
-
-            let D21_30_data_in = all_int_arr[i].filter(x => x.age < 40 && x.age>=30);   D21_30_data.push(D21_30_data_in.length);
-
-            let D21_40_data_in = all_int_arr[i].filter(x => x.age < 50 && x.age>=40);   D21_40_data.push(D21_40_data_in.length);
-
-            let D21_50_data_in = all_int_arr[i].filter(x => x.age < 60 && x.age>=50);   D21_50_data.push(D21_50_data_in.length);
-
-            let D21_60_data_in = all_int_arr[i].filter(x => x.age <= 120 && x.age>=60); D21_60_data.push(D21_60_data_in.length);
-
-
-            let D22_10_data_in = mail_all_int_arr[i].filter(x => x.age < 20);                D22_10_data.push(D22_10_data_in.length);
-
-            let D22_20_data_in = mail_all_int_arr[i].filter(x => x.age < 30 && x.age>=20);   D22_20_data.push(D22_20_data_in.length);
-
-            let D22_30_data_in = mail_all_int_arr[i].filter(x => x.age < 40 && x.age>=30);   D22_30_data.push(D22_30_data_in.length);
-
-            let D22_40_data_in = mail_all_int_arr[i].filter(x => x.age < 50 && x.age>=40);   D22_40_data.push(D22_40_data_in.length);
-
-            let D22_50_data_in = mail_all_int_arr[i].filter(x => x.age < 60 && x.age>=50);   D22_50_data.push(D22_50_data_in.length);
-
-            let D22_60_data_in = mail_all_int_arr[i].filter(x => x.age <= 120 && x.age>=60); D22_60_data.push(D22_60_data_in.length);
-
-
-            let D23_10_data_in = femail_all_int_arr[i].filter(x => x.age < 20);                D23_10_data.push(D23_10_data_in.length);
-
-            let D23_20_data_in = femail_all_int_arr[i].filter(x => x.age < 30 && x.age>=20);   D23_20_data.push(D23_20_data_in.length);
-
-            let D23_30_data_in = femail_all_int_arr[i].filter(x => x.age < 40 && x.age>=30);   D23_30_data.push(D23_30_data_in.length);
-
-            let D23_40_data_in = femail_all_int_arr[i].filter(x => x.age < 50 && x.age>=40);   D23_40_data.push(D23_40_data_in.length);
-
-            let D23_50_data_in = femail_all_int_arr[i].filter(x => x.age < 60 && x.age>=50);   D23_50_data.push(D23_50_data_in.length);
-
-            let D23_60_data_in = femail_all_int_arr[i].filter(x => x.age <= 120 && x.age>=60); D23_60_data.push(D23_60_data_in.length);
+            this.D23_10_data.push(D23_10_data_in.length);
+            this.D23_20_data.push(D23_20_data_in.length);
+            this.D23_30_data.push(D23_30_data_in.length);
+            this.D23_40_data.push(D23_40_data_in.length);
+            this.D23_50_data.push(D23_50_data_in.length);
+            this.D23_60_data.push(D23_60_data_in.length);
         };
-
-
-        this.A1_data = A1_data;
-        this.A21_data = A21_data;
-        this.A22_data = A22_data;
-        this.B1_10_data = B1_10_data;
-        this.B1_20_data = B1_20_data;
-        this.B1_30_data = B1_30_data;
-        this.B1_40_data = B1_40_data;
-        this.B1_50_data = B1_50_data;
-        this.B1_60_data = B1_60_data;
-        this.B2_10_data = B2_10_data;
-        this.B2_20_data = B2_20_data;
-        this.B2_30_data = B2_30_data;
-        this.B2_40_data = B2_40_data;
-        this.B2_50_data = B2_50_data;
-        this.B2_60_data = B2_60_data;
-        this.label_time_arr = label_time_arr;
-        this.C1_maxint_data = C1_maxint_data;
-        this.C1_nomalint_data = C1_nomalint_data;
-        this.C1_notint_data = C1_notint_data;
-        this.D11_10_data = D11_10_data;
-        this.D11_20_data = D11_20_data;
-        this.D11_30_data = D11_30_data;
-        this.D11_40_data = D11_40_data;
-        this.D11_50_data = D11_50_data;
-        this.D11_60_data = D11_60_data;
-        this.D12_10_data = D12_10_data;
-        this.D12_20_data = D12_20_data;
-        this.D12_30_data = D12_30_data;
-        this.D12_40_data = D12_40_data;
-        this.D12_50_data = D12_50_data;
-        this.D12_60_data = D12_60_data;
-        this.D13_10_data = D13_10_data;
-        this.D13_20_data = D13_20_data;
-        this.D13_30_data = D13_30_data;
-        this.D13_40_data = D13_40_data;
-        this.D13_50_data = D13_50_data;
-        this.D13_60_data = D13_60_data;
-        this.D21_10_data = D21_10_data;
-        this.D21_20_data = D21_20_data;
-        this.D21_30_data = D21_30_data;
-        this.D21_40_data = D21_40_data;
-        this.D21_50_data = D21_50_data;
-        this.D21_60_data = D21_60_data;
-        this.D22_10_data = D22_10_data;
-        this.D22_20_data = D22_20_data;
-        this.D22_30_data = D22_30_data;
-        this.D22_40_data = D22_40_data;
-        this.D22_50_data = D22_50_data;
-        this.D22_60_data = D22_60_data;
-        this.D23_10_data = D23_10_data;
-        this.D23_20_data = D23_20_data;
-        this.D23_30_data = D23_30_data;
-        this.D23_40_data = D23_40_data;
-        this.D23_50_data = D23_50_data;
-        this.D23_60_data = D23_60_data;
     };
 };

--- a/js/datain.js
+++ b/js/datain.js
@@ -123,21 +123,21 @@ class DataIN{
 
 
         //時間変化ラベル作成    
-        for(let h=user_intime-32400 ;h<(user_outtime-32400)+div_time ;h=h+div_time){
+        for(let h = user_intime - 32400 ; h < (user_outtime - 32400) + div_time ; h = h + div_time){
             label_unix_in.push(h);
         };
 
         for(let i=0 ;i<plot_num ;i=i+1){
-            let label_time_in= new Date(label_unix_in[i]*1000);
-            let label_time_in_2=label_time_in.getMonth()+1+"/"+label_time_in.getDate()+"/ "+label_time_in.getHours()+":"+label_time_in.getMinutes();
+            let label_time_in = new Date(label_unix_in[i] * 1000);
+            let label_time_in_2 = label_time_in.getMonth() + 1 + "/" + label_time_in.getDate() + "/ " + label_time_in.getHours() + ":" + label_time_in.getMinutes();
             this.label_time_arr.push(label_time_in_2);
         };
 
         //関心度分割
-        let all_max_int_arr   = backdata_arr.filter(x => x.interested <=100 && x.interested>max_intline );
-        let all_nomal_int_arr = backdata_arr.filter(x => x.interested <=max_intline && x.interested>not_intline );
-        let all_all_int_arr   = backdata_arr.filter(x => x.interested <=100 && x.interested>not_intline );
-        let all_not_int_arr   = backdata_arr.filter(x => x.interested <=not_intline && x.interested>=0  );           
+        let all_max_int_arr   = backdata_arr.filter(x => x.interested <= 100 && x.interested > max_intline);
+        let all_nomal_int_arr = backdata_arr.filter(x => x.interested <= max_intline && x.interested > not_intline);
+        let all_all_int_arr   = backdata_arr.filter(x => x.interested <= 100 && x.interested > not_intline);
+        let all_not_int_arr   = backdata_arr.filter(x => x.interested <= not_intline && x.interested >= 0);           
 
 
         //性別分割
@@ -148,7 +148,7 @@ class DataIN{
 
         //時間分割無しのgraphプロット変数in
         //A1
-        this.A1_data = [all_max_int_arr  .length, all_nomal_int_arr.length , all_not_int_arr  .length];
+        this.A1_data = [all_max_int_arr.length ,all_nomal_int_arr.length ,all_not_int_arr.length];
 
         //A21
         this.A21_data = [all_mail_max_int_arr_in.length ,all_femail_max_int_arr_in.length];
@@ -158,17 +158,17 @@ class DataIN{
 
         //B1
         let B1_mail_10_data_in   = all_mail_max_int_arr_in.filter(x => x.age < 20);    
-        let B1_mail_20_data_in   = all_mail_max_int_arr_in.filter(x => x.age < 30 && x.age>=20);    
-        let B1_mail_30_data_in   = all_mail_max_int_arr_in.filter(x => x.age < 40 && x.age>=30);
-        let B1_mail_40_data_in   = all_mail_max_int_arr_in.filter(x => x.age < 50 && x.age>=40);
-        let B1_mail_50_data_in   = all_mail_max_int_arr_in.filter(x => x.age < 60 && x.age>=50);    
-        let B1_mail_60_data_in   = all_mail_max_int_arr_in.filter(x => x.age <= 120 && x.age>=60);
+        let B1_mail_20_data_in   = all_mail_max_int_arr_in.filter(x => x.age < 30 && x.age >= 20);    
+        let B1_mail_30_data_in   = all_mail_max_int_arr_in.filter(x => x.age < 40 && x.age >= 30);
+        let B1_mail_40_data_in   = all_mail_max_int_arr_in.filter(x => x.age < 50 && x.age >= 40);
+        let B1_mail_50_data_in   = all_mail_max_int_arr_in.filter(x => x.age < 60 && x.age >= 50);    
+        let B1_mail_60_data_in   = all_mail_max_int_arr_in.filter(x => x.age <= 120 && x.age >= 60);
         let B1_femail_10_data_in = all_femail_max_int_arr_in.filter(x => x.age < 20);      
-        let B1_femail_20_data_in = all_femail_max_int_arr_in.filter(x => x.age < 30 && x.age>=20);      
-        let B1_femail_30_data_in = all_femail_max_int_arr_in.filter(x => x.age < 40 && x.age>=30);  
-        let B1_femail_40_data_in = all_femail_max_int_arr_in.filter(x => x.age < 50 && x.age>=40);  
-        let B1_femail_50_data_in = all_femail_max_int_arr_in.filter(x => x.age < 60 && x.age>=50);       
-        let B1_femail_60_data_in = all_femail_max_int_arr_in.filter(x => x.age <= 120 && x.age>=60);
+        let B1_femail_20_data_in = all_femail_max_int_arr_in.filter(x => x.age < 30 && x.age >= 20);      
+        let B1_femail_30_data_in = all_femail_max_int_arr_in.filter(x => x.age < 40 && x.age >= 30);  
+        let B1_femail_40_data_in = all_femail_max_int_arr_in.filter(x => x.age < 50 && x.age >= 40);  
+        let B1_femail_50_data_in = all_femail_max_int_arr_in.filter(x => x.age < 60 && x.age >= 50);       
+        let B1_femail_60_data_in = all_femail_max_int_arr_in.filter(x => x.age <= 120 && x.age >= 60);
 
         this.B1_10_data = [B1_mail_10_data_in.length,B1_femail_10_data_in.length];
         this.B1_20_data = [B1_mail_20_data_in.length,B1_femail_20_data_in.length];
@@ -179,17 +179,17 @@ class DataIN{
 
         //B2
         let B2_mail_10_data_in   = all_mail_all_int_arr_in.filter(x => x.age < 20);           
-        let B2_mail_20_data_in   = all_mail_all_int_arr_in.filter(x => x.age < 30 && x.age>=20);           
-        let B2_mail_30_data_in   = all_mail_all_int_arr_in.filter(x => x.age < 40 && x.age>=30);       
-        let B2_mail_40_data_in   = all_mail_all_int_arr_in.filter(x => x.age < 50 && x.age>=40);       
-        let B2_mail_50_data_in   = all_mail_all_int_arr_in.filter(x => x.age < 60 && x.age>=50);            
-        let B2_mail_60_data_in   = all_mail_all_int_arr_in.filter(x => x.age <= 120 && x.age>=60);      
+        let B2_mail_20_data_in   = all_mail_all_int_arr_in.filter(x => x.age < 30 && x.age >= 20);           
+        let B2_mail_30_data_in   = all_mail_all_int_arr_in.filter(x => x.age < 40 && x.age >= 30);       
+        let B2_mail_40_data_in   = all_mail_all_int_arr_in.filter(x => x.age < 50 && x.age >= 40);       
+        let B2_mail_50_data_in   = all_mail_all_int_arr_in.filter(x => x.age < 60 && x.age >= 50);            
+        let B2_mail_60_data_in   = all_mail_all_int_arr_in.filter(x => x.age <= 120 && x.age >= 60);      
         let B2_femail_10_data_in = all_femail_all_int_arr_in.filter(x => x.age < 20);            
-        let B2_femail_20_data_in = all_femail_all_int_arr_in.filter(x => x.age < 30 && x.age>=20);            
-        let B2_femail_30_data_in = all_femail_all_int_arr_in.filter(x => x.age < 40 && x.age>=30);        
-        let B2_femail_40_data_in = all_femail_all_int_arr_in.filter(x => x.age < 50 && x.age>=40);        
-        let B2_femail_50_data_in = all_femail_all_int_arr_in.filter(x => x.age < 60 && x.age>=50);             
-        let B2_femail_60_data_in = all_femail_all_int_arr_in.filter(x => x.age <= 120 && x.age>=60);   
+        let B2_femail_20_data_in = all_femail_all_int_arr_in.filter(x => x.age < 30 && x.age >= 20);            
+        let B2_femail_30_data_in = all_femail_all_int_arr_in.filter(x => x.age < 40 && x.age >= 30);        
+        let B2_femail_40_data_in = all_femail_all_int_arr_in.filter(x => x.age < 50 && x.age >= 40);        
+        let B2_femail_50_data_in = all_femail_all_int_arr_in.filter(x => x.age < 60 && x.age >= 50);             
+        let B2_femail_60_data_in = all_femail_all_int_arr_in.filter(x => x.age <= 120 && x.age >= 60);   
 
         this.B2_10_data = [B2_mail_10_data_in.length,B2_femail_10_data_in.length];
         this.B2_20_data = [B2_mail_20_data_in.length,B2_femail_20_data_in.length];
@@ -201,23 +201,23 @@ class DataIN{
 
         //時間分割
         for(let i=0 ;i<max_time ;i=i+div_time){
-            let backdata_arr_time_in = backdata_arr.filter(x => x.end_time_unix <= user_intime+(i+div_time) && x.end_time_unix > user_intime+i );
+            let backdata_arr_time_in = backdata_arr.filter(x => x.end_time_unix <= user_intime+(i+div_time) && x.end_time_unix > user_intime + i);
             backdata_arr_time.push(backdata_arr_time_in);
         };
 
 
         for(let i=0 ;i<plot_num ;i=i+1){
             //関心度分割
-            let max_int_arr_in = backdata_arr_time[i].filter(x => x.interested <=100 && x.interested>=max_intline);
+            let max_int_arr_in = backdata_arr_time[i].filter(x => x.interested <= 100 && x.interested >= max_intline);
             max_int_arr.push(max_int_arr_in);
 
-            let nomal_int_arr_in = backdata_arr_time[i].filter(x => x.interested <max_intline && x.interested>not_intline );
+            let nomal_int_arr_in = backdata_arr_time[i].filter(x => x.interested < max_intline && x.interested > not_intline);
             nomal_int_arr.push(nomal_int_arr_in);
 
-            let all_int_arr_in = backdata_arr_time[i].filter(x => x.interested <=100 && x.interested>not_intline );
+            let all_int_arr_in = backdata_arr_time[i].filter(x => x.interested <= 100 && x.interested > not_intline);
             all_int_arr.push(all_int_arr_in);
 
-            let not_int_arr_in = backdata_arr_time[i].filter(x => x.interested <=not_intline && x.interested>=0  );
+            let not_int_arr_in = backdata_arr_time[i].filter(x => x.interested <= not_intline && x.interested >=0);
             not_int_arr.push(not_int_arr_in);
 
             //性別分割
@@ -243,11 +243,11 @@ class DataIN{
 
             //D11
             let D11_10_data_in = max_int_arr[i].filter(x => x.age < 20);
-            let D11_20_data_in = max_int_arr[i].filter(x => x.age < 30 && x.age>=20);
-            let D11_30_data_in = max_int_arr[i].filter(x => x.age < 40 && x.age>=30);
-            let D11_40_data_in = max_int_arr[i].filter(x => x.age < 50 && x.age>=40);
-            let D11_50_data_in = max_int_arr[i].filter(x => x.age < 60 && x.age>=50);
-            let D11_60_data_in = max_int_arr[i].filter(x => x.age <= 120 && x.age>=60);
+            let D11_20_data_in = max_int_arr[i].filter(x => x.age < 30 && x.age >= 20);
+            let D11_30_data_in = max_int_arr[i].filter(x => x.age < 40 && x.age >= 30);
+            let D11_40_data_in = max_int_arr[i].filter(x => x.age < 50 && x.age >= 40);
+            let D11_50_data_in = max_int_arr[i].filter(x => x.age < 60 && x.age >= 50);
+            let D11_60_data_in = max_int_arr[i].filter(x => x.age <= 120 && x.age >= 60);
 
             this.D11_10_data.push(D11_10_data_in.length); 
             this.D11_20_data.push(D11_20_data_in.length); 
@@ -258,11 +258,11 @@ class DataIN{
 
             //D12
             let D12_10_data_in = male_max_int_arr[i].filter(x => x.age < 20);
-            let D12_20_data_in = male_max_int_arr[i].filter(x => x.age < 30 && x.age>=20);
-            let D12_30_data_in = male_max_int_arr[i].filter(x => x.age < 40 && x.age>=30);
-            let D12_40_data_in = male_max_int_arr[i].filter(x => x.age < 50 && x.age>=40);
-            let D12_50_data_in = male_max_int_arr[i].filter(x => x.age < 60 && x.age>=50);
-            let D12_60_data_in = male_max_int_arr[i].filter(x => x.age <= 120 && x.age>=60); 
+            let D12_20_data_in = male_max_int_arr[i].filter(x => x.age < 30 && x.age >= 20);
+            let D12_30_data_in = male_max_int_arr[i].filter(x => x.age < 40 && x.age >= 30);
+            let D12_40_data_in = male_max_int_arr[i].filter(x => x.age < 50 && x.age >= 40);
+            let D12_50_data_in = male_max_int_arr[i].filter(x => x.age < 60 && x.age >= 50);
+            let D12_60_data_in = male_max_int_arr[i].filter(x => x.age <= 120 && x.age >= 60); 
 
             this.D12_10_data.push(D12_10_data_in.length);
             this.D12_20_data.push(D12_20_data_in.length);
@@ -273,11 +273,11 @@ class DataIN{
 
             //D13
             let D13_10_data_in = female_max_int_arr[i].filter(x => x.age < 20);
-            let D13_20_data_in = female_max_int_arr[i].filter(x => x.age < 30 && x.age>=20);
-            let D13_30_data_in = female_max_int_arr[i].filter(x => x.age < 40 && x.age>=30);
-            let D13_40_data_in = female_max_int_arr[i].filter(x => x.age < 50 && x.age>=40);
-            let D13_50_data_in = female_max_int_arr[i].filter(x => x.age < 60 && x.age>=50);
-            let D13_60_data_in = female_max_int_arr[i].filter(x => x.age <= 120 && x.age>=60);
+            let D13_20_data_in = female_max_int_arr[i].filter(x => x.age < 30 && x.age >= 20);
+            let D13_30_data_in = female_max_int_arr[i].filter(x => x.age < 40 && x.age >= 30);
+            let D13_40_data_in = female_max_int_arr[i].filter(x => x.age < 50 && x.age >= 40);
+            let D13_50_data_in = female_max_int_arr[i].filter(x => x.age < 60 && x.age >= 50);
+            let D13_60_data_in = female_max_int_arr[i].filter(x => x.age <= 120 && x.age >= 60);
 
             this.D13_10_data.push(D13_10_data_in.length);
             this.D13_20_data.push(D13_20_data_in.length);
@@ -288,11 +288,11 @@ class DataIN{
 
             //D21
             let D21_10_data_in = all_int_arr[i].filter(x => x.age < 20);
-            let D21_20_data_in = all_int_arr[i].filter(x => x.age < 30 && x.age>=20);
-            let D21_30_data_in = all_int_arr[i].filter(x => x.age < 40 && x.age>=30);
-            let D21_40_data_in = all_int_arr[i].filter(x => x.age < 50 && x.age>=40);
-            let D21_50_data_in = all_int_arr[i].filter(x => x.age < 60 && x.age>=50);
-            let D21_60_data_in = all_int_arr[i].filter(x => x.age <= 120 && x.age>=60);
+            let D21_20_data_in = all_int_arr[i].filter(x => x.age < 30 && x.age >= 20);
+            let D21_30_data_in = all_int_arr[i].filter(x => x.age < 40 && x.age >= 30);
+            let D21_40_data_in = all_int_arr[i].filter(x => x.age < 50 && x.age >= 40);
+            let D21_50_data_in = all_int_arr[i].filter(x => x.age < 60 && x.age >= 50);
+            let D21_60_data_in = all_int_arr[i].filter(x => x.age <= 120 && x.age >= 60);
 
             this.D21_10_data.push(D21_10_data_in.length);
             this.D21_20_data.push(D21_20_data_in.length);
@@ -303,11 +303,11 @@ class DataIN{
 
             //D22
             let D22_10_data_in = male_all_int_arr[i].filter(x => x.age < 20);
-            let D22_20_data_in = male_all_int_arr[i].filter(x => x.age < 30 && x.age>=20);
-            let D22_30_data_in = male_all_int_arr[i].filter(x => x.age < 40 && x.age>=30);
-            let D22_40_data_in = male_all_int_arr[i].filter(x => x.age < 50 && x.age>=40);
-            let D22_50_data_in = male_all_int_arr[i].filter(x => x.age < 60 && x.age>=50);
-            let D22_60_data_in = male_all_int_arr[i].filter(x => x.age <= 120 && x.age>=60);
+            let D22_20_data_in = male_all_int_arr[i].filter(x => x.age < 30 && x.age >= 20);
+            let D22_30_data_in = male_all_int_arr[i].filter(x => x.age < 40 && x.age >= 30);
+            let D22_40_data_in = male_all_int_arr[i].filter(x => x.age < 50 && x.age >= 40);
+            let D22_50_data_in = male_all_int_arr[i].filter(x => x.age < 60 && x.age >= 50);
+            let D22_60_data_in = male_all_int_arr[i].filter(x => x.age <= 120 && x.age >= 60);
 
             this.D22_10_data.push(D22_10_data_in.length);
             this.D22_20_data.push(D22_20_data_in.length);
@@ -318,11 +318,11 @@ class DataIN{
 
             //D23
             let D23_10_data_in = female_all_int_arr[i].filter(x => x.age < 20);
-            let D23_20_data_in = female_all_int_arr[i].filter(x => x.age < 30 && x.age>=20);
-            let D23_30_data_in = female_all_int_arr[i].filter(x => x.age < 40 && x.age>=30);
-            let D23_40_data_in = female_all_int_arr[i].filter(x => x.age < 50 && x.age>=40);
-            let D23_50_data_in = female_all_int_arr[i].filter(x => x.age < 60 && x.age>=50);
-            let D23_60_data_in = female_all_int_arr[i].filter(x => x.age <= 120 && x.age>=60); 
+            let D23_20_data_in = female_all_int_arr[i].filter(x => x.age < 30 && x.age >= 20);
+            let D23_30_data_in = female_all_int_arr[i].filter(x => x.age < 40 && x.age >= 30);
+            let D23_40_data_in = female_all_int_arr[i].filter(x => x.age < 50 && x.age >= 40);
+            let D23_50_data_in = female_all_int_arr[i].filter(x => x.age < 60 && x.age >= 50);
+            let D23_60_data_in = female_all_int_arr[i].filter(x => x.age <= 120 && x.age >= 60); 
 
             this.D23_10_data.push(D23_10_data_in.length);
             this.D23_20_data.push(D23_20_data_in.length);

--- a/js/grahp.js
+++ b/js/grahp.js
@@ -39,17 +39,17 @@ class MICSGrahp{
     //グラフの描画
     #LoadGrahps(){
         this.#GrahpA1();
-        this.#GrahpA21();
-        this.#GrahpA22();
-        this.#GrahpB1();
-        this.#GrahpB2();
+        this.#GrahpA2('graph_A21',this.data.A21_data);
+        this.#GrahpA2('graph_A22',this.data.A22_data);
+        this.#GrahpB('graph_B1',this.data.B1_10_data,this.data.B1_20_data,this.data.B1_30_data,this.data.B1_40_data,this.data.B1_50_data,this.data.B1_60_data);
+        this.#GrahpB('graph_B2',this.data.B2_10_data,this.data.B2_20_data,this.data.B2_30_data,this.data.B2_40_data,this.data.B2_50_data,this.data.B2_60_data);
         this.#GrahpC1();
-        this.#GrahpD11();
-        this.#GrahpD12();
-        this.#GrahpD13();
-        this.#GrahpD21();
-        this.#GrahpD22();
-        this.#GrahpD23();
+        this.#GrahpD('graph_D11',this.data.D11_10_data,this.data.D11_20_data,this.data.D11_30_data,this.data.D11_40_data,this.data.D11_50_data,this.data.D11_60_data);
+        this.#GrahpD('graph_D12',this.data.D12_10_data,this.data.D12_20_data,this.data.D12_30_data,this.data.D12_40_data,this.data.D12_50_data,this.data.D12_60_data);
+        this.#GrahpD('graph_D13',this.data.D13_10_data,this.data.D13_20_data,this.data.D13_30_data,this.data.D13_40_data,this.data.D13_50_data,this.data.D13_60_data);
+        this.#GrahpD('graph_D21',this.data.D21_10_data,this.data.D21_20_data,this.data.D21_30_data,this.data.D21_40_data,this.data.D21_50_data,this.data.D21_60_data);
+        this.#GrahpD('graph_D22',this.data.D22_10_data,this.data.D22_20_data,this.data.D22_30_data,this.data.D22_40_data,this.data.D22_50_data,this.data.D22_60_data);
+        this.#GrahpD('graph_D23',this.data.D23_10_data,this.data.D23_20_data,this.data.D23_30_data,this.data.D23_40_data,this.data.D23_50_data,this.data.D23_60_data);
     }
 
     //それぞれのグラフを表示する関数
@@ -58,7 +58,6 @@ class MICSGrahp{
         const element = document.getElementById('graph_A1').getContext('2d');
         const chart = new Chart(element, {
             type:'pie',
-            // データを指定
             data: {
                 labels: ["特に関心あり", "関心あり", "関心なし"],
                 datasets: [{
@@ -73,42 +72,25 @@ class MICSGrahp{
        });
     }
 
-    #GrahpA21(){
-        const element = document.getElementById('graph_A21').getContext('2d');
+    #GrahpA2(id, data){
+        const element = document.getElementById(id).getContext('2d');
         const chart = new Chart(element, {
             type:'pie',
             data: {
                 labels: ["女性", "男性"],
                 datasets: [{
-                  backgroundColor: [
-                  'rgba(255, 99, 132, 1)',
-                  'rgba(54, 162, 235, 1)'
-                  ],
-                  data: this.data.A21_data
+                    backgroundColor: [
+                    'rgba(255, 99, 132, 1)',
+                    'rgba(54, 162, 235, 1)'
+                    ],
+                    data: data
                 }]
             },
        });
     }
 
-    #GrahpA22(){
-        const element = document.getElementById('graph_A22').getContext('2d');
-        const chart = new Chart(element, {
-            type:'pie',
-            data: {
-                labels: ["女性", "男性"],
-                datasets: [{
-                  backgroundColor: [
-                  'rgba(255, 99, 132, 1)',
-                  'rgba(54, 162, 235, 1)'
-                  ],
-                  data: this.data.A22_data
-                }]
-            },
-       });
-    }
-
-    #GrahpB1(){
-        const element = document.getElementById('graph_B1').getContext('2d');
+    #GrahpB(id, data_10, data_20, data_30, data_40, data_50, data_60){
+        const element = document.getElementById(id).getContext('2d');
         Chart.register(ChartjsPluginStacked100.default);
         const chart = new Chart(element, {
             type:'bar',
@@ -118,7 +100,7 @@ class MICSGrahp{
                 {
                     barPercentage:0.6,
                     label:           "10代以下",
-                    data:            this.data.B1_10_data,
+                    data:            data_10,
                     backgroundColor: "rgba(220,53,69, 0.8)",
                     borderColor:     "rgba(220,53,69, 1.0)",
                     borderWidth:     1,
@@ -126,7 +108,7 @@ class MICSGrahp{
                 {
                     barPercentage:0.6,
                     label:           "20代",
-                    data:            this.data.B1_20_data,
+                    data:            data_20,
                     backgroundColor: "rgba(255,142,10, 0.8)",
                     borderColor:     "rgba(255,142,10, 1.0)",
                     borderWidth:     1,
@@ -134,7 +116,7 @@ class MICSGrahp{
                 {
                     barPercentage:0.6,
                     label:           "30代",
-                    data:            this.data.B1_30_data,
+                    data:            data_30,
                     backgroundColor: "rgba(255,228,88, 0.8)",
                     borderColor:     "rgba(255,228,88, 1.0)",
                     borderWidth:     1,
@@ -142,7 +124,7 @@ class MICSGrahp{
                 {
                     barPercentage:0.6,
                     label:           "40代",
-                    data:            this.data.B1_40_data,
+                    data:            data_40,
                     backgroundColor: "rgba(84,241,100, 0.8)",
                     borderColor:     "rgba(84,241,100, 1.0)",
                     borderWidth:     1,
@@ -150,7 +132,7 @@ class MICSGrahp{
                 {
                     barPercentage:0.6,
                     label:           "50代",
-                    data:            this.data.B1_50_data,
+                    data:            data_50,
                     backgroundColor: "rgba(53,90,220, 0.8)",
                     borderColor:     "rgba(53,90,220, 1.0)",
                     borderWidth:     1,
@@ -158,12 +140,11 @@ class MICSGrahp{
                 {
                     barPercentage:0.6,
                     label:           "60代以上",
-                    data:            this.data.B1_60_data,
+                    data:            data_60,
                     backgroundColor: "rgba(151,71,255, 0.8)",
                     borderColor:     "rgba(151,71,255, 1.0)",
                     borderWidth:     1,
-                },
-                ],
+                }],
             },
             options: {
                 responsive: true,
@@ -171,78 +152,7 @@ class MICSGrahp{
                 plugins: {
                     stacked100: { enable: true },
                 },
-                
             },
-       });
-    }
-
-    #GrahpB2(){
-        const element = document.getElementById('graph_B2').getContext('2d')
-        Chart.register(ChartjsPluginStacked100.default);
-        const chart = new Chart(element, {
-            type:'bar',
-            data: {
-                labels: ["女性", "男性"],
-                datasets: [
-                  {
-                    barPercentage:0.6,
-                    label:           "10代以下",
-                    data:            this.data.B2_10_data,
-                    backgroundColor: "rgba(220,53,69, 0.8)",
-                    borderColor:     "rgba(220,53,69, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    barPercentage:0.6,
-                    label:           "20代",
-                    data:            this.data.B2_20_data,
-                    backgroundColor: "rgba(255,142,10, 0.8)",
-                    borderColor:     "rgba(255,142,10, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    barPercentage:0.6,
-                    label:           "30代",
-                    data:            this.data.B2_30_data,
-                    backgroundColor: "rgba(255,228,88, 0.8)",
-                    borderColor:     "rgba(255,228,88, 1.0)",
-                    borderWidth:     1,
-                },
-                {
-                    barPercentage:0.6,
-                    label:           "40代",
-                    data:            this.data.B2_40_data,
-                    backgroundColor: "rgba(84,241,100, 0.8)",
-                    borderColor:     "rgba(84,241,100, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    barPercentage:0.6,
-                    label:           "50代",
-                    data:            this.data.B2_50_data,
-                    backgroundColor: "rgba(53,90,220, 0.8)",
-                    borderColor:     "rgba(53,90,220, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                  barPercentage:0.6,
-                    label:           "60代以上",
-                    data:            this.data.B2_60_data,
-                    backgroundColor: "rgba(151,71,255, 0.8)",
-                    borderColor:     "rgba(151,71,255, 1.0)",
-                    borderWidth:     1,
-                },
-                ],
-
-            },
-                options: {
-                    responsive: true,
-                    indexAxis: "y",
-                    plugins: {
-                        stacked100: { enable: true },
-                    }
-                }
-            
        });
     }
 
@@ -278,30 +188,29 @@ class MICSGrahp{
                     borderWidth:     1,
                 }],
             },
-                options: {
-                    responsive: true,
-                    scales: {
-                        x: {
-                            display:      true,
-                            stacked:      true,
-                            suggestedMax: 100,
-                            suggestedMin: 0,
-                            ticks: {
-                            stepSize: 10,
-                            },
+            options: {
+                responsive: true,
+                scales: {
+                    x: {
+                        display:      true,
+                        stacked:      true,
+                        suggestedMax: 100,
+                        suggestedMin: 0,
+                        ticks: {
+                        stepSize: 10,
                         },
-                        y: {
-                            display:      true,
-                            stacked:      true,
-                        }
+                    },
+                    y: {
+                        display:      true,
+                        stacked:      true,
                     }
                 }
-            
+            }
         });
     }
 
-    #GrahpD11(){
-        const element = document.getElementById('graph_D11').getContext('2d');
+    #GrahpD(id, data_10, data_20, data_30, data_40, data_50, data_60){
+        const element = document.getElementById(id).getContext('2d');
         const chart = new Chart(element, {
             type:'bar',
             data: {
@@ -310,7 +219,7 @@ class MICSGrahp{
                 {
                     barPercentage:0.6,
                     label:           "10代以下",
-                    data:            this.data.D11_10_data,
+                    data:            data_10,
                     backgroundColor: "rgba(220,53,69, 0.8)",
                     borderColor:     "rgba(220,53,69, 1.0)",
                     borderWidth:     1,
@@ -318,7 +227,7 @@ class MICSGrahp{
                 {
                     barPercentage:0.6,
                     label:           "20代",
-                    data:            this.data.D11_20_data,
+                    data:            data_20,
                     backgroundColor: "rgba(255,142,10, 0.8)",
                     borderColor:     "rgba(255,142,10, 1.0)",
                     borderWidth:     1,
@@ -326,7 +235,7 @@ class MICSGrahp{
                 {
                     barPercentage:0.6,
                     label:           "30代",
-                    data:            this.data.D11_30_data,
+                    data:            data_30,
                     backgroundColor: "rgba(255,228,88, 0.8)",
                     borderColor:     "rgba(255,228,88, 1.0)",
                     borderWidth:     1,
@@ -334,7 +243,7 @@ class MICSGrahp{
                 {
                     barPercentage:0.6,
                     label:           "40代",
-                    data:            this.data.D11_40_data,
+                    data:            data_40,
                     backgroundColor: "rgba(84,241,100, 0.8)",
                     borderColor:     "rgba(84,241,100, 1.0)",
                     borderWidth:     1,
@@ -342,7 +251,7 @@ class MICSGrahp{
                 {
                     barPercentage:0.6,
                     label:           "50代",
-                    data:            this.data.D11_50_data,
+                    data:            data_50,
                     backgroundColor: "rgba(53,90,220, 0.8)",
                     borderColor:     "rgba(53,90,220, 1.0)",
                     borderWidth:     1,
@@ -351,255 +260,15 @@ class MICSGrahp{
                     
                     barPercentage:0.6,
                     label:           "60代以上",
-                    data:            this.data.D11_60_data,
+                    data:            data_60,
                     backgroundColor: "rgba(151,71,255, 0.8)",
                     borderColor:     "rgba(151,71,255, 1.0)",
                     borderWidth:     1,
-                }
-                ],
+                }],
             },
-                options: {
-                   responsive: true,
-                   scales: {
-                        x: {
-                            display:      true,
-                            stacked:      true,
-                            suggestedMax: 100,
-                            suggestedMin: 0,
-                            ticks: {
-                                stepSize: 10,
-                            },
-                        },
-                        y: {
-                            display:      true,
-                            stacked:      true,
-                        }
-                    }
-                }
-            
-       });
-    }
-
-    #GrahpD12(){
-        const element = document.getElementById('graph_D12').getContext('2d');
-        const chart = new Chart(element, {
-            type:'bar',
-            data: {
-                labels: this.data.label_time_arr,
-                datasets: [
-                {
-                    barPercentage:0.6,
-                    label:           "10代以下",
-                    data:            this.data.D12_10_data,
-                    backgroundColor: "rgba(220,53,69, 0.8)",
-                    borderColor:     "rgba(220,53,69, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    
-                    barPercentage:0.6,
-                    label:           "20代",
-                    data:            this.data.D12_20_data,
-                    backgroundColor: "rgba(255,142,10, 0.8)",
-                    borderColor:     "rgba(255,142,10, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    barPercentage:0.6,
-                    label:           "30代",
-                    data:            this.data.D12_30_data,
-                    backgroundColor: "rgba(255,228,88, 0.8)",
-                    borderColor:     "rgba(255,228,88, 1.0)",
-                    borderWidth:     1,
-                },
-                {
-                barPercentage:0.6,
-                label:               "40代",
-                    data:            this.data.D12_40_data,
-                    backgroundColor: "rgba(84,241,100, 0.8)",
-                    borderColor:     "rgba(84,241,100, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    barPercentage:0.6,
-                    label:           "50代",
-                    data:            this.data.D12_50_data,
-                    backgroundColor: "rgba(53,90,220, 0.8)",
-                    borderColor:     "rgba(53,90,220, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    
-                    barPercentage:0.6,
-                    label:           "60代以上",
-                    data:            this.data.D12_60_data,
-                    backgroundColor: "rgba(151,71,255, 0.8)",
-                    borderColor:     "rgba(151,71,255, 1.0)",
-                    borderWidth:     1,
-                }
-                ],
-                },
-                options: {
-                    responsive: true,
-                    scales: {
-                    x: {
-                        display:      true,
-                        stacked:      true,
-                        suggestedMax: 100,
-                        suggestedMin: 0,
-                        ticks: {
-                        stepSize: 10,
-                        },
-                    },
-                    y: {
-                        display:      true,
-                        stacked:      true,
-                    }
-                }
-            }
-       });
-    }
-
-    #GrahpD13(){
-        const element = document.getElementById('graph_D13').getContext('2d');
-        const chart = new Chart(element, {
-            type:'bar',
-            data: {
-                labels: this.data.label_time_arr,
-                datasets: [
-                {
-                    barPercentage:0.6,
-                    label:           "10代以下",
-                    data:            this.data.D13_10_data,
-                    backgroundColor: "rgba(220,53,69, 0.8)",
-                    borderColor:     "rgba(220,53,69, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    barPercentage:0.6,
-                    label:           "20代",
-                    data:            this.data.D13_20_data,
-                    backgroundColor: "rgba(255,142,10, 0.8)",
-                    borderColor:     "rgba(255,142,10, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    barPercentage:0.6,
-                    label:           "30代",
-                    data:            this.data.D13_30_data,
-                    backgroundColor: "rgba(255,228,88, 0.8)",
-                    borderColor:     "rgba(255,228,88, 1.0)",
-                    borderWidth:     1,
-                },
-                {
-                    barPercentage:0.6,
-                    label:           "40代",
-                    data:            this.data.D13_40_data,
-                    backgroundColor: "rgba(84,241,100, 0.8)",
-                    borderColor:     "rgba(84,241,100, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    barPercentage:0.6,
-                    label:           "50代",
-                    data:            this.data.D13_50_data,
-                    backgroundColor: "rgba(53,90,220, 0.8)",
-                    borderColor:     "rgba(53,90,220, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    
-                    barPercentage:0.6,
-                    label:           "60代以上",
-                    data:            this.data.D13_60_data,
-                    backgroundColor: "rgba(151,71,255, 0.8)",
-                    borderColor:     "rgba(151,71,255, 1.0)",
-                    borderWidth:     1,
-                }
-                ],
-                },
-                options: {
-                    responsive: true,
-                    scales: {
-                    x: {
-                        display:      true,
-                        stacked:      true,
-                        suggestedMax: 100,
-                        suggestedMin: 0,
-                        ticks: {
-                        stepSize: 10,
-                        },
-                    },
-                    y: {
-                        display:      true,
-                        stacked:      true,
-                    }
-                }
-            }
-       });
-    }
-
-    #GrahpD21(){
-        const element = document.getElementById('graph_D21').getContext('2d');
-        const chart = new Chart(element, {
-            type:'bar',
-            data: {
-                labels: this.data.label_time_arr,
-                datasets: [
-                {
-                    barPercentage:0.6,
-                    label:           "10代以下",
-                    data:            this.data.D21_10_data,
-                    backgroundColor: "rgba(220,53,69, 0.8)",
-                    borderColor:     "rgba(220,53,69, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    barPercentage:0.6,
-                    label:           "20代",
-                    data:            this.data.D21_20_data,
-                    backgroundColor: "rgba(255,142,10, 0.8)",
-                    borderColor:     "rgba(255,142,10, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    barPercentage:0.6,
-                    label:           "30代",
-                    data:            this.data.D21_30_data,
-                    backgroundColor: "rgba(255,228,88, 0.8)",
-                    borderColor:     "rgba(255,228,88, 1.0)",
-                    borderWidth:     1,
-                },
-                {
-                    barPercentage:0.6,
-                    label:           "40代",
-                    data:            this.data.D21_40_data,
-                    backgroundColor: "rgba(84,241,100, 0.8)",
-                    borderColor:     "rgba(84,241,100, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    barPercentage:0.6,
-                    label:           "50代",
-                    data:            this.data.D21_50_data,
-                    backgroundColor: "rgba(53,90,220, 0.8)",
-                    borderColor:     "rgba(53,90,220, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    
-                    barPercentage:0.6,
-                    label:           "60代以上",
-                    data:            this.data.D21_60_data,
-                    backgroundColor: "rgba(151,71,255, 0.8)",
-                    borderColor:     "rgba(151,71,255, 1.0)",
-                    borderWidth:     1,
-                }
-                ],
-                },
-                options: {
-                  responsive: true,
-                   scales: {
+            options: {
+               responsive: true,
+               scales: {
                     x: {
                         display:      true,
                         stacked:      true,
@@ -616,164 +285,6 @@ class MICSGrahp{
                 }
             }
        });
-    }
-
-    #GrahpD22(){
-        const element = document.getElementById('graph_D22').getContext('2d');
-        const chart = new Chart(element, {
-            type:'bar',
-            data: {
-                labels: this.data.label_time_arr,
-                datasets: [
-                {
-                    barPercentage:0.6,
-                    label:           "10代以下",
-                    data:            this.data.D22_10_data,
-                    backgroundColor: "rgba(220,53,69, 0.8)",
-                    borderColor:     "rgba(220,53,69, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    
-                    barPercentage:0.6,
-                    label:           "20代",
-                    data:            this.data.D22_20_data,
-                    backgroundColor: "rgba(255,142,10, 0.8)",
-                    borderColor:     "rgba(255,142,10, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    barPercentage:0.6,
-                    label:           "30代",
-                    data:            this.data.D22_30_data,
-                    backgroundColor: "rgba(255,228,88, 0.8)",
-                    borderColor:     "rgba(255,228,88, 1.0)",
-                    borderWidth:     1,
-                },
-                {
-                    barPercentage:0.6,
-                    label:           "40代",
-                    data:            this.data.D22_40_data,
-                    backgroundColor: "rgba(84,241,100, 0.8)",
-                    borderColor:     "rgba(84,241,100, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    barPercentage:0.6,
-                    label:           "50代",
-                    data:            this.data.D22_50_data,
-                    backgroundColor: "rgba(53,90,220, 0.8)",
-                    borderColor:     "rgba(53,90,220, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    
-                    barPercentage:0.6,
-                    label:           "60代以上",
-                    data:            this.data.D22_60_data,
-                    backgroundColor: "rgba(151,71,255, 0.8)",
-                    borderColor:     "rgba(151,71,255, 1.0)",
-                    borderWidth:     1,
-                }
-                ],
-                },
-                options: {
-                    responsive: true,
-                    scales: {
-                    x: {
-                        display:      true,
-                        stacked:      true,
-                        suggestedMax: 100,
-                        suggestedMin: 0,
-                        ticks: {
-                        stepSize: 10,
-                        },
-                    },
-                    y: {
-                        display:      true,
-                        stacked:      true,
-                    }
-                }
-            }
-        });
-    }
-
-    #GrahpD23(){
-        const element = document.getElementById('graph_D23').getContext('2d');
-        const chart = new Chart(element, {
-            type:'bar',
-            data: {labels: this.data.label_time_arr,
-                datasets: [
-                {
-                    barPercentage:0.6,
-                    label:           "10代以下",
-                    data:            this.data.D23_10_data,
-                    backgroundColor: "rgba(220,53,69, 0.8)",
-                    borderColor:     "rgba(220,53,69, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    barPercentage:0.6,
-                    label:           "20代",
-                    data:            this.data.D23_20_data,
-                    backgroundColor: "rgba(255,142,10, 0.8)",
-                    borderColor:     "rgba(255,142,10, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    barPercentage:0.6,
-                    label:           "30代",
-                    data:            this.data.D23_30_data,
-                    backgroundColor: "rgba(255,228,88, 0.8)",
-                    borderColor:     "rgba(255,228,88, 1.0)",
-                    borderWidth:     1,
-                },
-                {
-                    barPercentage:0.6,
-                    label:           "40代",
-                    data:            this.data.D23_40_data,
-                    backgroundColor: "rgba(84,241,100, 0.8)",
-                    borderColor:     "rgba(84,241,100, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    barPercentage:0.6,
-                    label:           "50代",
-                    data:            this.data.D23_50_data,
-                    backgroundColor: "rgba(53,90,220, 0.8)",
-                    borderColor:     "rgba(53,90,220, 1.0)",
-                    borderWidth:     1,
-                }, 
-                {
-                    
-                    barPercentage:0.6,
-                    label:           "60代以上",
-                    data:            this.data.D23_60_data,
-                    backgroundColor: "rgba(151,71,255, 0.8)",
-                    borderColor:     "rgba(151,71,255, 1.0)",
-                    borderWidth:     1,
-                }
-                ],
-                },
-                options: {
-                    responsive: true,
-                    scales: {
-                    x: {
-                        display:      true,
-                        stacked:      true,
-                        suggestedMax: 100,
-                        suggestedMin: 0,
-                        ticks: {
-                            stepSize: 10,
-                        },
-                    },
-                        y: {
-                        display:      true,
-                        stacked:      true,
-                    }
-                }
-            }
-        });
     }
 
     //HTMLにグラフ部分を追加するする関数
@@ -904,7 +415,6 @@ class MICSGrahp{
         //DOM操作実行
         this.app_element = document.getElementById("app");
         this.app_element.insertAdjacentHTML('afterbegin', this.new_HTML_data);
-
 
         //ページ上部に戻るボタンのイベントを登録(デスクトップのみ)
         if (!navigator.userAgent.match(/iPhone|Android.+Mobile/)) {

--- a/js/grahp.js
+++ b/js/grahp.js
@@ -4,7 +4,7 @@ Grahp表示関係
 */
 
 //指定した要素を子含めて全削除
-function removeAll(element){
+function RemoveAll(element){
     while(element.firstChild){
         element.removeChild(element.firstChild);
     }
@@ -24,11 +24,11 @@ class MICSGrahp{
 
     //グラフの再描画
     Update(MICS_class){
-        removeAll(document.getElementById("graphA" ))
-        removeAll(document.getElementById("graphB" ))
-        removeAll(document.getElementById("graphC" ))
-        removeAll(document.getElementById("graphD1"))
-        removeAll(document.getElementById("graphD2"))
+        RemoveAll(document.getElementById("graphA" ))
+        RemoveAll(document.getElementById("graphB" ))
+        RemoveAll(document.getElementById("graphC" ))
+        RemoveAll(document.getElementById("graphD1"))
+        RemoveAll(document.getElementById("graphD2"))
         this.#AddGraphDOM();
         this.data = new DataIN(MICS_class.date_first, MICS_class.date_last, MICS_class.interest_data);
         this.#LoadGrahps();


### PR DESCRIPTION
## 概要
1. graph.jsのグラフ表示関数を改良して大幅に行数を減らしました。(ページ高速化)
2. datain.jsの変数のスペルミスとコードの体裁を修正しました。
3. datain.jsのメンバ関数data_processをプライベートメンバ関数に変更しました。
4. datain.jsの行数を削減しました。(ページ高速化)
5. htmlのjs読み込み順序を変更しました。(ページ高速化)
6. cssを変更してレイアウトを改良しました。